### PR TITLE
Better fix for mvnun issues

### DIFF
--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -12,7 +12,6 @@ from scipy._lib._util import check_random_state
 from scipy.linalg.blas import drot
 
 from ._discrete_distns import binom
-from ._continuous_distns import norm
 from . import mvn
 
 __all__ = ['multivariate_normal',
@@ -539,25 +538,11 @@ class multivariate_normal_gen(multi_rv_generic):
         .. versionadded:: 1.0.0
 
         """
-        dim = mean.shape[0]
-        if dim == 1:
-            # Cover univariate case separately, because mvndst would fail
-            out = norm.cdf(x, mean, np.sqrt(cov))
-        else:
-            # Standard deviation and integration bounds
-            stdev = np.sqrt(np.diag(cov))
-            lower = np.full(dim, -np.inf)
-            upper = (x - mean) / stdev
-            # Calculate correlation coefficients from covariance matrix
-            cor = cov / np.outer(stdev, stdev)
-            cor_vec = cor[np.tril_indices(dim, -1)]
-            # Integration limit flags
-            infin = np.zeros(dim, dtype=int)
-            # mvndst expects 1-d arguments, so process points sequentially
-            func1d = lambda upper1d: mvn.mvndst(lower, upper1d, infin,
-                                                cor_vec, maxpts, abseps,
-                                                releps)[1]
-            out = np.apply_along_axis(func1d, -1, upper)
+        lower = np.full(mean.shape, -np.inf)
+        # mvnun expects 1-d arguments, so process points sequentially
+        func1d = lambda x_slice: mvn.mvnun(lower, x_slice, mean, cov,
+                                           maxpts, abseps, releps)[0]
+        out = np.apply_along_axis(func1d, -1, x)
         return _squeeze_output(out)
 
     def logcdf(self, x, mean=None, cov=1, allow_singular=False, maxpts=None,

--- a/scipy/stats/mvndst.f
+++ b/scipy/stats/mvndst.f
@@ -42,12 +42,24 @@
       double precision lower(d), upper(d), releps, abseps,
      &                 error, value, stdev(d), rho(d*(d-1)/2), 
      &                 covar(d,d),
-     &                 nlower(d), nupper(d), means(d,n), tmpval
+     &                 nlower(d), nupper(d), means(d,n), tmpval,
+     &                 inf
       integer i, j
+
+      inf = 0d0
+      inf = 1d0 / inf
 
       do i=1,d
         stdev(i) = dsqrt(covar(i,i))
-        infin(i) = 2
+        if (upper(i).eq.inf.and.lower(i).eq.-inf) then
+           infin(i) = -1
+        else if (lower(i).eq.-inf) then
+           infin(i) = 0
+        else if (upper(i).eq.inf) then
+           infin(i) = 1
+        else
+           infin(i) = 2
+        end if
       end do
       do i=1,d
         do j=1,i-1


### PR DESCRIPTION
Rather than doing a partial reimplementation of mvnun in Python, fix how it sets the infinity integration flags. This seems to solve the issues in it.